### PR TITLE
Reduce the builds number which could cause storage overwhelm

### DIFF
--- a/maven/NOS-972/fast-local/indy-build/test/test.yml
+++ b/maven/NOS-972/fast-local/indy-build/test/test.yml
@@ -5,18 +5,18 @@ build:
   builds: 15
 report:
   threads: 2
-vagrant:
-  pre-build:
-    run:
-      - 
-        host: indy
-        commands:
-          - "sudo rm -rf /tmp/build*"
-          - "sudo systemctl stop indy"
-          - "sudo systemctl start indy"
-        wait-for-indy: true
-  build: 
-    
-  post-build:
-    copy:
-      'indy:/opt/indy/var/log/indy/': '{project_dir}/indy-logs/'
+#vagrant:
+#  pre-build:
+#    run:
+#      - 
+#        host: indy
+#        commands:
+#          - "sudo rm -rf /tmp/build*"
+#          - "sudo systemctl stop indy"
+#          - "sudo systemctl start indy"
+#        wait-for-indy: true
+#  build: 
+#    
+#  post-build:
+#    copy:
+#      'indy:/opt/indy/var/log/indy/': '{project_dir}/indy-logs/'

--- a/maven/NOS-972/fast-local/indy-build/test/test.yml
+++ b/maven/NOS-972/fast-local/indy-build/test/test.yml
@@ -1,8 +1,8 @@
-proxy-port: 8081
+#proxy-port: 8081
 build:
   threads: 6
   git-branch: test
-  builds: 30
+  builds: 15
 report:
   threads: 2
 vagrant:


### PR DESCRIPTION
And comment the proxy because of some npm build(like indy)